### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build Docker
       run: ./gradlew buildDocker
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ewized/mapnodes/mapnodes:spongevanilla
         username: ewized


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore